### PR TITLE
Add 3 L's retro template

### DIFF
--- a/src/main/resources/templates/three-ls.yml
+++ b/src/main/resources/templates/three-ls.yml
@@ -1,0 +1,31 @@
+name: 3 L's
+description: >
+  The 3 L's retro focuses on learning and growth. Team members reflect on what they Liked,
+  what they Learned, and what they Lacked over the period being reviewed. It works well for
+  teams that want to surface takeaways and gaps in a lightweight, forward-looking way.
+
+
+  Liked: What went well? What did you enjoy or want to keep doing?
+
+  Learned: What new insights, skills, or information did you gain?
+
+  Lacked: What was missing? What did you need but didn't have?
+categories:
+  - name: "Liked"
+    position: 1
+    lightBackgroundColor: "#3498db"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#2980b9"
+    darkTextColor: "#ffffff"
+  - name: "Learned"
+    position: 2
+    lightBackgroundColor: "#2ecc71"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#27ae60"
+    darkTextColor: "#ffffff"
+  - name: "Lacked"
+    position: 3
+    lightBackgroundColor: "#e74c3c"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#c0392b"
+    darkTextColor: "#ffffff"


### PR DESCRIPTION
## Summary

Adds a new **3 L's** retro template — a lightweight, learning-focused format with three columns: **Liked**, **Learned**, and **Lacked**.

Templates are auto-discovered by `TemplateConfig` from `src/main/resources/templates/*.yml` (the filename becomes the template id), so this is a single-file, data-only change — no Java or wiring changes required.

## Details

- **File:** `src/main/resources/templates/three-ls.yml` (id: `three-ls.yml`)
- **Categories / colors:**
  - Liked — blue (`#3498db` / `#2980b9`)
  - Learned — green (`#2ecc71` / `#27ae60`)
  - Lacked — red (`#e74c3c` / `#c0392b`)
- Colors reuse the existing palette convention already used by the Happy-Confused-Sad template.
- The `retro-ui` frontend renders any template the API returns, so no frontend change is needed.

## Verification

- Validated the YAML parses and its structure matches the schema of all four existing templates exactly (top-level `name`/`description`/`categories`, and each category has the six required fields with an integer `position`).
- Full JVM test suite was not run locally (no Java 21 runtime on this machine); this is a static data file that adds no logic. Existing `TemplateConfigTest` runs against separate fixtures under `src/test/resources/templates/` and is unaffected. CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)