### PR TITLE
Add Team Health Check retro template

### DIFF
--- a/src/main/resources/templates/team-health-check.yml
+++ b/src/main/resources/templates/team-health-check.yml
@@ -1,0 +1,48 @@
+name: Team Health Check
+description: >
+  The Team Health Check is meant to gauge the overall state of the team across several dimensions rather than
+  react to a single event. Team members reflect on how things feel right now in each area, surfacing both strengths
+  to protect and stresses to address. It works well on a recurring cadence to track how the team's health trends
+  over time.
+
+
+  Energy & Morale: How are we feeling? Are we motivated or running on empty?
+
+  Workload & Pace: Is our pace sustainable, or are we stretched too thin?
+
+  Collaboration & Communication: How well are we working together and sharing information?
+
+  Clarity & Direction: Do we know where we're going and why?
+
+  Growth & Learning: Are we developing our skills and growing as a team?
+categories:
+  - name: "Energy & Morale"
+    position: 1
+    lightBackgroundColor: "#2ecc71"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#27ae60"
+    darkTextColor: "#ffffff"
+  - name: "Workload & Pace"
+    position: 2
+    lightBackgroundColor: "#e67e22"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#d35400"
+    darkTextColor: "#ffffff"
+  - name: "Collaboration & Communication"
+    position: 3
+    lightBackgroundColor: "#3498db"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#2980b9"
+    darkTextColor: "#ffffff"
+  - name: "Clarity & Direction"
+    position: 4
+    lightBackgroundColor: "#9b59b6"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#8e44ad"
+    darkTextColor: "#ffffff"
+  - name: "Growth & Learning"
+    position: 5
+    lightBackgroundColor: "#1abc9c"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#16a085"
+    darkTextColor: "#ffffff"


### PR DESCRIPTION
## Summary

Adds a **Team Health Check** retro template — a recurring-cadence format for gauging the overall state of the team across five dimensions rather than reacting to a single event.

Templates are auto-discovered by `TemplateConfig` from `src/main/resources/templates/*.yml` (the filename becomes the template id), so this is a single-file, data-only change — no Java or wiring changes required.

## Details

- **File:** `src/main/resources/templates/team-health-check.yml` (id: `team-health-check.yml`)
- **Categories:**
  1. Energy & Morale
  2. Workload & Pace
  3. Collaboration & Communication
  4. Clarity & Direction
  5. Growth & Learning
- The `retro-ui` frontend renders any template the API returns, so no frontend change is needed.

## Verification

- Validated the YAML parses and its structure matches the schema of the existing templates: top-level `name`/`description`/`categories`, each category has the six required fields with an integer `position`, and positions are sequential 1–5.
- Full JVM test suite was not run locally (no Java 21 runtime on this machine); this is a static data file that adds no logic. Existing `TemplateConfigTest` runs against separate fixtures under `src/test/resources/templates/` and is unaffected. CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)