### PR TITLE
Add per-category descriptions to templates

### DIFF
--- a/src/main/java/io/nickreuter/retroapi/retro/template/Category.java
+++ b/src/main/java/io/nickreuter/retroapi/retro/template/Category.java
@@ -2,6 +2,7 @@ package io.nickreuter.retroapi.retro.template;
 
 public record Category (
     String name,
+    String description,
     int position,
     String lightBackgroundColor,
     String lightTextColor,

--- a/src/main/resources/templates/happy-confused-sad.yml
+++ b/src/main/resources/templates/happy-confused-sad.yml
@@ -13,18 +13,21 @@ description: >
   Sad: What is something that saddened or angered you? How do we prevent that from happening again?
 categories:
   - name: "Happy"
+    description: "What made you feel happy? What could we do to continue it?"
     position: 1
     lightBackgroundColor: "#2ecc71"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#27ae60"
     darkTextColor: "#ffffff"
   - name: "Confused"
+    description: "What confused you? What could help clear it up?"
     position: 2
     lightBackgroundColor: "#3498db"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#2980b9"
     darkTextColor: "#ffffff"
   - name: "Sad"
+    description: "What saddened or frustrated you? How might we prevent it?"
     position: 3
     lightBackgroundColor: "#e74c3c"
     lightTextColor: "#ffffff"

--- a/src/main/resources/templates/hot-air-balloon.yml
+++ b/src/main/resources/templates/hot-air-balloon.yml
@@ -3,12 +3,14 @@ description: >
   The Hot Air Balloon retro is meant to help us identify the things that lift us up and the things that drag us down as we try to soar to effectiveness.
 categories:
   - name: "What makes us fly towards our goals?"
+    description: "The things lifting us up and moving us toward our goals."
     position: 1
     lightBackgroundColor: "#2ecc71"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#27ae60"
     darkTextColor: "#ffffff"
   - name: "What pushes us back?"
+    description: "The things weighing us down or slowing our progress."
     position: 2
     lightBackgroundColor: "#3498db"
     lightTextColor: "#ffffff"

--- a/src/main/resources/templates/plus-delta.yml
+++ b/src/main/resources/templates/plus-delta.yml
@@ -2,12 +2,14 @@ name: Plus Delta
 description: Template used for quick, small sessions to gain feedback on a specific idea or action. Examples include after pairing, after a meeting, after an event
 categories:
   - name: "Plus"
+    description: "What went well and is worth keeping or repeating?"
     position: 1
     lightBackgroundColor: "#2ecc71"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#27ae60"
     darkTextColor: "#ffffff"
   - name: "Delta"
+    description: "What would you change or do differently next time?"
     position: 2
     lightBackgroundColor: "#3498db"
     lightTextColor: "#ffffff"

--- a/src/main/resources/templates/sailboat.yml
+++ b/src/main/resources/templates/sailboat.yml
@@ -2,24 +2,28 @@ name: Sailboat
 description: Useful on a more infrequent basis, and is meant to get participants to take a step back and look at the project as a whole.
 categories:
   - name: "Wind in our sails"
+    description: "What's propelling us forward and helping us move faster?"
     position: 1
     lightBackgroundColor: "#F4D797"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#FFCE61"
     darkTextColor: "#ffffff"
   - name: "Anchor dragging us down"
+    description: "What's holding us back or slowing our progress?"
     position: 2
     lightBackgroundColor: "#B5728E"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#50366F"
     darkTextColor: "#ffffff"
   - name: "Hazards ahead"
+    description: "Risks or obstacles we can see coming that could threaten us."
     position: 3
     lightBackgroundColor: "#DA7F7D"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#BF3475"
     darkTextColor: "#ffffff"
   - name: "What we are moving towards"
+    description: "The goal or destination we're steering toward."
     position: 4
     lightBackgroundColor: "#EBB58A"
     lightTextColor: "#ffffff"

--- a/src/main/resources/templates/team-health-check.yml
+++ b/src/main/resources/templates/team-health-check.yml
@@ -1,0 +1,48 @@
+name: Team Health Check
+description: >
+  The Team Health Check is meant to gauge the overall state of the team across several dimensions rather than
+  react to a single event. Team members reflect on how things feel right now in each area, surfacing both strengths
+  to protect and stresses to address. It works well on a recurring cadence to track how the team's health trends
+  over time.
+
+
+  Energy & Morale: How are we feeling? Are we motivated or running on empty?
+
+  Workload & Pace: Is our pace sustainable, or are we stretched too thin?
+
+  Collaboration & Communication: How well are we working together and sharing information?
+
+  Clarity & Direction: Do we know where we're going and why?
+
+  Growth & Learning: Are we developing our skills and growing as a team?
+categories:
+  - name: "Energy & Morale"
+    position: 1
+    lightBackgroundColor: "#2ecc71"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#27ae60"
+    darkTextColor: "#ffffff"
+  - name: "Workload & Pace"
+    position: 2
+    lightBackgroundColor: "#e67e22"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#d35400"
+    darkTextColor: "#ffffff"
+  - name: "Collaboration & Communication"
+    position: 3
+    lightBackgroundColor: "#3498db"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#2980b9"
+    darkTextColor: "#ffffff"
+  - name: "Clarity & Direction"
+    position: 4
+    lightBackgroundColor: "#9b59b6"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#8e44ad"
+    darkTextColor: "#ffffff"
+  - name: "Growth & Learning"
+    position: 5
+    lightBackgroundColor: "#1abc9c"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#16a085"
+    darkTextColor: "#ffffff"

--- a/src/main/resources/templates/team-health-check.yml
+++ b/src/main/resources/templates/team-health-check.yml
@@ -17,30 +17,35 @@ description: >
   Growth & Learning: Are we developing our skills and growing as a team?
 categories:
   - name: "Energy & Morale"
+    description: "How are we feeling? Are we motivated or running on empty?"
     position: 1
     lightBackgroundColor: "#2ecc71"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#27ae60"
     darkTextColor: "#ffffff"
   - name: "Workload & Pace"
+    description: "Is our pace sustainable, or are we stretched too thin?"
     position: 2
     lightBackgroundColor: "#e67e22"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#d35400"
     darkTextColor: "#ffffff"
   - name: "Collaboration & Communication"
+    description: "How well are we working together and sharing information?"
     position: 3
     lightBackgroundColor: "#3498db"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#2980b9"
     darkTextColor: "#ffffff"
   - name: "Clarity & Direction"
+    description: "Do we know where we're going and why?"
     position: 4
     lightBackgroundColor: "#9b59b6"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#8e44ad"
     darkTextColor: "#ffffff"
   - name: "Growth & Learning"
+    description: "Are we developing our skills and growing as a team?"
     position: 5
     lightBackgroundColor: "#1abc9c"
     lightTextColor: "#ffffff"

--- a/src/main/resources/templates/three-ls.yml
+++ b/src/main/resources/templates/three-ls.yml
@@ -12,18 +12,21 @@ description: >
   Lacked: What was missing? What did you need but didn't have?
 categories:
   - name: "Liked"
+    description: "What went well? What did you enjoy or want to keep doing?"
     position: 1
     lightBackgroundColor: "#3498db"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#2980b9"
     darkTextColor: "#ffffff"
   - name: "Learned"
+    description: "What new insights, skills, or information did you gain?"
     position: 2
     lightBackgroundColor: "#2ecc71"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#27ae60"
     darkTextColor: "#ffffff"
   - name: "Lacked"
+    description: "What was missing? What did you need but didn't have?"
     position: 3
     lightBackgroundColor: "#e74c3c"
     lightTextColor: "#ffffff"

--- a/src/main/resources/templates/three-ls.yml
+++ b/src/main/resources/templates/three-ls.yml
@@ -1,0 +1,31 @@
+name: 3 L's
+description: >
+  The 3 L's retro focuses on learning and growth. Team members reflect on what they Liked,
+  what they Learned, and what they Lacked over the period being reviewed. It works well for
+  teams that want to surface takeaways and gaps in a lightweight, forward-looking way.
+
+
+  Liked: What went well? What did you enjoy or want to keep doing?
+
+  Learned: What new insights, skills, or information did you gain?
+
+  Lacked: What was missing? What did you need but didn't have?
+categories:
+  - name: "Liked"
+    position: 1
+    lightBackgroundColor: "#3498db"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#2980b9"
+    darkTextColor: "#ffffff"
+  - name: "Learned"
+    position: 2
+    lightBackgroundColor: "#2ecc71"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#27ae60"
+    darkTextColor: "#ffffff"
+  - name: "Lacked"
+    position: 3
+    lightBackgroundColor: "#e74c3c"
+    lightTextColor: "#ffffff"
+    darkBackgroundColor: "#c0392b"
+    darkTextColor: "#ffffff"

--- a/src/test/java/io/nickreuter/retroapi/retro/RetroServiceTest.java
+++ b/src/test/java/io/nickreuter/retroapi/retro/RetroServiceTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.*;
 
 class RetroServiceTest {
     private final RetroRepository retroRepository = mock(RetroRepository.class);
-    private final Template savedTemplate = new Template("template", "name", "description", List.of(new Category("column", 1, "", "", "", "")));
+    private final Template savedTemplate = new Template("template", "name", "description", List.of(new Category("column", "", 1, "", "", "", "")));
     private final ApplicationEventPublisher applicationEventPublisher = mock(ApplicationEventPublisher.class);
     private final RetroService subject = new RetroService(retroRepository, List.of(savedTemplate), applicationEventPublisher);
 

--- a/src/test/java/io/nickreuter/retroapi/retro/template/TemplateConfigTest.java
+++ b/src/test/java/io/nickreuter/retroapi/retro/template/TemplateConfigTest.java
@@ -28,16 +28,16 @@ class TemplateConfigTest {
                     "Happy, Confused, Sad",
                     "Description",
                     List.of(
-                        new Category("Happy", 1, "#ffffff", "#ffffff", "#ffffff", "#ffffff"),
-                        new Category("Confused", 2, "#ffffff", "#ffffff", "#ffffff", "#ffffff"),
-                        new Category("Sad", 3, "#ffffff", "#ffffff", "#ffffff", "#ffffff")
+                        new Category("Happy", "Happy description", 1, "#ffffff", "#ffffff", "#ffffff", "#ffffff"),
+                        new Category("Confused", "Confused description", 2, "#ffffff", "#ffffff", "#ffffff", "#ffffff"),
+                        new Category("Sad", "Sad description", 3, "#ffffff", "#ffffff", "#ffffff", "#ffffff")
                     )
                 ),
                 new Template(
                         "valid-1-column.yml",
                         "Happy",
                         "Description",
-                        List.of(new Category("Happy", 1, "#ffffff", "#ffffff", "#ffffff", "#ffffff"))
+                        List.of(new Category("Happy", "Happy description", 1, "#ffffff", "#ffffff", "#ffffff", "#ffffff"))
                 )
         );
     }
@@ -54,9 +54,9 @@ class TemplateConfigTest {
                         "Happy, Confused, Sad",
                         "Description",
                         List.of(
-                                new Category("Happy", 1, "#ffffff", "#ffffff", "#ffffff", "#ffffff"),
-                                new Category("Confused", 2, "#ffffff", "#ffffff", "#ffffff", "#ffffff"),
-                                new Category("Sad", 3, "#ffffff", "#ffffff", "#ffffff", "#ffffff")
+                                new Category("Happy", "Happy description", 1, "#ffffff", "#ffffff", "#ffffff", "#ffffff"),
+                                new Category("Confused", "Confused description", 2, "#ffffff", "#ffffff", "#ffffff", "#ffffff"),
+                                new Category("Sad", "Sad description", 3, "#ffffff", "#ffffff", "#ffffff", "#ffffff")
                         )
                 )
         );

--- a/src/test/resources/templates/valid-1-column.yml
+++ b/src/test/resources/templates/valid-1-column.yml
@@ -2,6 +2,7 @@ name: Happy
 description: Description
 categories:
   - name: "Happy"
+    description: "Happy description"
     position: 1
     lightBackgroundColor: "#ffffff"
     lightTextColor: "#ffffff"

--- a/src/test/resources/templates/valid-3-column.yml
+++ b/src/test/resources/templates/valid-3-column.yml
@@ -2,21 +2,23 @@ name: Happy, Confused, Sad
 description: Description
 categories:
   - name: "Happy"
+    description: "Happy description"
     position: 1
     lightBackgroundColor: "#ffffff"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#ffffff"
     darkTextColor: "#ffffff"
   - name: "Confused"
+    description: "Confused description"
     position: 2
     lightBackgroundColor: "#ffffff"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#ffffff"
     darkTextColor: "#ffffff"
   - name: "Sad"
+    description: "Sad description"
     position: 3
     lightBackgroundColor: "#ffffff"
     lightTextColor: "#ffffff"
     darkBackgroundColor: "#ffffff"
     darkTextColor: "#ffffff"
-


### PR DESCRIPTION
## Summary

Adds a `description` field to template categories so the UI can explain what each column is for (e.g. a tooltip on the retro board). Every category across all six templates now has a concise description.

This is the backend half of the feature; the [retro-ui side](https://github.com/LowBudgetMan/retro-ui/pull/35) renders `category.description` on hover and treats the field as optional, so the two can land in either order.

## Changes

- **`Category` record** — new `description` field (loaded straight from template YAML by the existing Jackson/YAML parsing; no parsing or endpoint changes). Because the retro object already embeds `template.categories`, descriptions flow through automatically.
- **All 6 templates** — per-category `description` added: Plus Delta, Happy-Confused-Sad, Hot Air Balloon, Sailboat, 3 L's, and Team Health Check (19 categories total).
- **Tests** — updated the `Category` constructor call sites in `TemplateConfigTest` and `RetroServiceTest`, and added `description` to the test fixtures.
<img width="382" height="258" alt="image" src="https://github.com/user-attachments/assets/2c3ff3b8-5887-4e5b-8744-c303f0acfbee" />


## Testing

- `./gradlew test` — green.
- Ran the app locally against the frontend and confirmed `GET /api/templates` serves descriptions for all 19 categories and they render on the retro board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)